### PR TITLE
corrected class name to be identical has file name

### DIFF
--- a/cassinglesignon
+++ b/cassinglesignon
@@ -1,7 +1,7 @@
 gs.include("PrototypeServer");
 
-var CASSingleSignon = Class.create();
-CASSingleSignon.prototype = {
+var CASSingleSignOn = Class.create();
+CASSingleSignOn.prototype = {
     initialize: function() {
         this.service = gs.getProperty("glide.servlet.uri");
         this.caslogin = gs.getProperty("glide.authenticate.cas.loginurl");


### PR DESCRIPTION
the name of the script include in the Readme.md is a little different than the real name of the script include (typo on the 'O' of on that isn't caps).
Spent some time finding the problem on this issue while trying to deploy it
